### PR TITLE
Update ape.en.mdx

### DIFF
--- a/pages/techniques/ape.en.mdx
+++ b/pages/techniques/ape.en.mdx
@@ -14,7 +14,7 @@ The first step involves a large language model (as an inference model) that is g
 
 APE discovers a better zero-shot CoT prompt than the human engineered "Let's think step by step" prompt ([Kojima et al., 2022](https://arxiv.org/abs/2205.11916)).
 
-The prompt "Let's work this out it a step by step to be sure we have the right answer." elicits chain-of-though reasoning and improves performance on the MultiArith and GSM8K benchmarks:
+The prompt "Let’s work this out in a step by step way to be sure we have the right answer." elicits chain-of-though reasoning and improves performance on the MultiArith and GSM8K benchmarks:
 
 <Screenshot src={APECOT} alt="APECOT" />
 Image Source: [Zhou et al., (2022)](https://arxiv.org/abs/2211.01910)

--- a/pages/techniques/ape.en.mdx
+++ b/pages/techniques/ape.en.mdx
@@ -14,7 +14,7 @@ The first step involves a large language model (as an inference model) that is g
 
 APE discovers a better zero-shot CoT prompt than the human engineered "Let's think step by step" prompt ([Kojima et al., 2022](https://arxiv.org/abs/2205.11916)).
 
-The prompt "Let’s work this out in a step by step way to be sure we have the right answer." elicits chain-of-though reasoning and improves performance on the MultiArith and GSM8K benchmarks:
+The prompt "Let's work this out in a step by step way to be sure we have the right answer." elicits chain-of-though reasoning and improves performance on the MultiArith and GSM8K benchmarks:
 
 <Screenshot src={APECOT} alt="APECOT" />
 Image Source: [Zhou et al., (2022)](https://arxiv.org/abs/2211.01910)


### PR DESCRIPTION
The Automatic Prompt Engineer paper claims that this prompt elicits better results:

"Let’s work this out **in** a step by step **way** to be sure we have the right answer."

But the prompt in the ape.en.mdx file misquotes the prompt:

"Let’s work this out **it** a step by step to be sure we have the right answer."