### PR TITLE
add Knit to Tools pages

### DIFF
--- a/pages/tools.en.mdx
+++ b/pages/tools.en.mdx
@@ -15,6 +15,7 @@
 - [GPTTools](https://gpttools.com/comparisontool)
 - [hwchase17/adversarial-prompts](https://github.com/hwchase17/adversarial-prompts)
 - [Interactive Composition Explorer](https://github.com/oughtinc/ice)
+- [Knit](https://promptknit.com)
 - [LangChain](https://github.com/hwchase17/langchain)
 - [Lexica](https://lexica.art)
 - [LMFlow](https://github.com/OptimalScale/LMFlow)

--- a/pages/tools.es.mdx
+++ b/pages/tools.es.mdx
@@ -14,6 +14,7 @@
 - [GPTTools](https://gpttools.com/comparisontool)
 - [hwchase17/adversarial-prompts](https://github.com/hwchase17/adversarial-prompts)
 - [Interactive Composition Explorer](https://github.com/oughtinc/ice)
+- [Knit](https://promptknit.com)
 - [LangChain](https://github.com/hwchase17/langchain)
 - [Lexica](https://lexica.art)
 - [loom](https://github.com/socketteer/loom)

--- a/pages/tools.fi.mdx
+++ b/pages/tools.fi.mdx
@@ -15,6 +15,7 @@
 - [GPTTools](https://gpttools.com/comparisontool)
 - [hwchase17/adversarial-prompts](https://github.com/hwchase17/adversarial-prompts)
 - [Interactive Composition Explorer](https://github.com/oughtinc/ice)
+- [Knit](https://promptknit.com)
 - [LangChain](https://github.com/hwchase17/langchain)
 - [Lexica](https://lexica.art)
 - [LMFlow](https://github.com/OptimalScale/LMFlow)

--- a/pages/tools.fr.mdx
+++ b/pages/tools.fr.mdx
@@ -14,6 +14,7 @@
 - [GPTTools](https://gpttools.com/comparisontool)
 - [hwchase17/adversarial-prompts](https://github.com/hwchase17/adversarial-prompts)
 - [Interactive Composition Explorer](https://github.com/oughtinc/ice)
+- [Knit](https://promptknit.com)
 - [LangChain](https://github.com/hwchase17/langchain)
 - [Lexica](https://lexica.art)
 - [loom](https://github.com/socketteer/loom)

--- a/pages/tools.it.mdx
+++ b/pages/tools.it.mdx
@@ -14,6 +14,7 @@
 - [GPTTools](https://gpttools.com/comparisontool)
 - [hwchase17/adversarial-prompts](https://github.com/hwchase17/adversarial-prompts)
 - [Interactive Composition Explorer](https://github.com/oughtinc/ice)
+- [Knit](https://promptknit.com)
 - [LangChain](https://github.com/hwchase17/langchain)
 - [Lexica](https://lexica.art)
 - [loom](https://github.com/socketteer/loom)

--- a/pages/tools.jp.mdx
+++ b/pages/tools.jp.mdx
@@ -13,6 +13,7 @@
 - [GPTTools](https://gpttools.com/comparisontool)
 - [hwchase17/adversarial-prompts](https://github.com/hwchase17/adversarial-prompts)
 - [Interactive Composition Explorer](https://github.com/oughtinc/ice)
+- [Knit](https://promptknit.com)
 - [LangChain](https://github.com/hwchase17/langchain)
 - [Lexica](https://lexica.art)
 - [LMFlow](https://github.com/OptimalScale/LMFlow)

--- a/pages/tools.kr.mdx
+++ b/pages/tools.kr.mdx
@@ -14,6 +14,7 @@
 - [GPTTools](https://gpttools.com/comparisontool)
 - [hwchase17/adversarial-prompts](https://github.com/hwchase17/adversarial-prompts)
 - [Interactive Composition Explorer](https://github.com/oughtinc/ice)
+- [Knit](https://promptknit.com)
 - [LangChain](https://github.com/hwchase17/langchain)
 - [Lexica](https://lexica.art)
 - [loom](https://github.com/socketteer/loom)

--- a/pages/tools.pt.mdx
+++ b/pages/tools.pt.mdx
@@ -14,6 +14,7 @@
 - [GPTTools](https://gpttools.com/comparisontool)
 - [hwchase17/adversarial-prompts](https://github.com/hwchase17/adversarial-prompts)
 - [Interactive Composition Explorer](https://github.com/oughtinc/ice)
+- [Knit](https://promptknit.com)
 - [LangChain](https://github.com/hwchase17/langchain)
 - [Lexica](https://lexica.art)
 - [LMFlow](https://github.com/OptimalScale/LMFlow)

--- a/pages/tools.tr.mdx
+++ b/pages/tools.tr.mdx
@@ -14,6 +14,7 @@
 - [GPTTools](https://gpttools.com/comparisontool)
 - [hwchase17/adversarial-prompts](https://github.com/hwchase17/adversarial-prompts)
 - [Interactive Composition Explorer](https://github.com/oughtinc/ice)
+- [Knit](https://promptknit.com)
 - [LangChain](https://github.com/hwchase17/langchain)
 - [Lexica](https://lexica.art)
 - [LMFlow](https://github.com/OptimalScale/LMFlow)

--- a/pages/tools.zh.mdx
+++ b/pages/tools.zh.mdx
@@ -14,6 +14,7 @@
 - [GPTTools](https://gpttools.com/comparisontool)
 - [hwchase17/adversarial-prompts](https://github.com/hwchase17/adversarial-prompts)
 - [Interactive Composition Explorer](https://github.com/oughtinc/ice)
+- [Knit](https://promptknit.com)
 - [LangChain](https://github.com/hwchase17/langchain)
 - [Lexica](https://lexica.art)
 - [LMFlow](https://github.com/OptimalScale/LMFlow)


### PR DESCRIPTION
[Knit](https://promptknit.com) is a SaaS tool for teams to collaborate on prompt development.

Features including:

- Store/edit/run/share prompts based on all kinds of models.
- Member access settings for prompts, team members can edit/view/run prompts.
- Full version control to all members of the prompts. Roll back the edits anytime.

<img width="1630" alt="2023-05-29 at 2 36 PM" src="https://github.com/dair-ai/Prompt-Engineering-Guide/assets/1134651/91a5891f-c95c-43b8-b83d-7a2ed526017c">

cc @omarsar 
