### PR TITLE
Replaced search tool with google-serper

### DIFF
--- a/notebooks/pe-lecture.ipynb
+++ b/notebooks/pe-lecture.ipynb
@@ -91,7 +91,7 @@
     "\n",
     "# for LangChain\n",
     "os.environ[\"OPENAI_API_KEY\"] = os.getenv(\"OPENAI_API_KEY\")\n",
-    "os.environ[\"SERPAPI_API_KEY\"] = os.getenv(\"SERPAPI_API_KEY\")"
+    "os.environ[\"SERPER_API_KEY\"] = os.getenv(\"SERPER_API_KEY\")"
    ]
   },
   {
@@ -910,7 +910,7 @@
    "source": [
     "llm = OpenAI(temperature=0)\n",
     "\n",
-    "tools = load_tools([\"serpapi\", \"llm-math\"], llm=llm)\n",
+    "tools = load_tools([\"google-serper\", \"llm-math\"], llm=llm)\n",
     "agent = initialize_agent(tools, llm, agent=\"zero-shot-react-description\", verbose=True)"
    ]
   },

--- a/notebooks/react.ipynb
+++ b/notebooks/react.ipynb
@@ -32,7 +32,7 @@
     "\n",
     "# load API keys; you will need to obtain these if you haven't yet\n",
     "os.environ[\"OPENAI_API_KEY\"] = os.getenv(\"OPENAI_API_KEY\")\n",
-    "os.environ[\"SERPAPI_API_KEY\"] = os.getenv(\"SERPAPI_API_KEY\")"
+    "os.environ[\"SERPER_API_KEY\"] = os.getenv(\"SERPER_API_KEY\")"
    ]
   },
   {
@@ -42,7 +42,7 @@
    "outputs": [],
    "source": [
     "llm = OpenAI(model_name=\"text-davinci-003\" ,temperature=0)\n",
-    "tools = load_tools([\"serpapi\", \"llm-math\"], llm=llm)\n",
+    "tools = load_tools([\"google-serper\", \"llm-math\"], llm=llm)\n",
     "agent = initialize_agent(tools, llm, agent=\"zero-shot-react-description\", verbose=True)"
    ]
   },

--- a/pages/techniques/react.ca.mdx
+++ b/pages/techniques/react.ca.mdx
@@ -126,7 +126,7 @@ load_dotenv()
 
 # carrega les claus API; hauràs d'obtenir-les si encara no les tens
 os.environ["OPENAI_API_KEY"] = os.getenv("OPENAI_API_KEY")
-os.environ["SERPAPI_API_KEY"] = os.getenv("SERPAPI_API_KEY")
+os.environ["SERPER_API_KEY"] = os.getenv("SERPER_API_KEY")
 
 ```
 
@@ -134,7 +134,7 @@ Ara podem configurar l'LLM, les eines que utilitzarem i l'agent que ens permet u
 
 ``` python
 llm = OpenAI(model_name="text-davinci-003" ,temperature=0)
-tools = load_tools(["serpapi", "llm-math"], llm=llm)
+tools = load_tools(["google-serper", "llm-math"], llm=llm)
 agent = initialize_agent(tools, llm, agent="zero-shot-react-description", verbose=True)
 ```
 

--- a/pages/techniques/react.en.mdx
+++ b/pages/techniques/react.en.mdx
@@ -127,7 +127,7 @@ load_dotenv()
 
 # load API keys; you will need to obtain these if you haven't yet
 os.environ["OPENAI_API_KEY"] = os.getenv("OPENAI_API_KEY")
-os.environ["SERPAPI_API_KEY"] = os.getenv("SERPAPI_API_KEY")
+os.environ["SERPER_API_KEY"] = os.getenv("SERPER_API_KEY")
 
 ```
 
@@ -135,7 +135,7 @@ Now we can configure the LLM, the tools we will use, and the agent that allows u
 
 ``` python
 llm = OpenAI(model_name="text-davinci-003" ,temperature=0)
-tools = load_tools(["serpapi", "llm-math"], llm=llm)
+tools = load_tools(["google-serper", "llm-math"], llm=llm)
 agent = initialize_agent(tools, llm, agent="zero-shot-react-description", verbose=True)
 ```
 

--- a/pages/techniques/react.fi.mdx
+++ b/pages/techniques/react.fi.mdx
@@ -116,7 +116,7 @@ load_dotenv()
 
 # load API keys; you will need to obtain these if you haven't yet
 os.environ["OPENAI_API_KEY"] = os.getenv("OPENAI_API_KEY")
-os.environ["SERPAPI_API_KEY"] = os.getenv("SERPAPI_API_KEY")
+os.environ["SERPER_API_KEY"] = os.getenv("SERPER_API_KEY")
 
 ```
 

--- a/pages/techniques/react.ru.mdx
+++ b/pages/techniques/react.ru.mdx
@@ -126,7 +126,7 @@ load_dotenv()
 
 # load API keys; you will need to obtain these if you haven't yet
 os.environ["OPENAI_API_KEY"] = os.getenv("OPENAI_API_KEY")
-os.environ["SERPAPI_API_KEY"] = os.getenv("SERPAPI_API_KEY")
+os.environ["SERPER_API_KEY"] = os.getenv("SERPER_API_KEY")
 
 ```
 
@@ -134,7 +134,7 @@ os.environ["SERPAPI_API_KEY"] = os.getenv("SERPAPI_API_KEY")
 
 ``` python
 llm = OpenAI(model_name="text-davinci-003" ,temperature=0)
-tools = load_tools(["serpapi", "llm-math"], llm=llm)
+tools = load_tools(["google-serper", "llm-math"], llm=llm)
 agent = initialize_agent(tools, llm, agent="zero-shot-react-description", verbose=True)
 ```
 

--- a/pages/techniques/react.zh.mdx
+++ b/pages/techniques/react.zh.mdx
@@ -116,7 +116,7 @@ load_dotenv()
 
 # 载入 API keys; 如果没有，你需要先获取。 
 os.environ["OPENAI_API_KEY"] = os.getenv("OPENAI_API_KEY")
-os.environ["SERPAPI_API_KEY"] = os.getenv("SERPAPI_API_KEY")
+os.environ["SERPER_API_KEY"] = os.getenv("SERPER_API_KEY")
 
 ```
 
@@ -124,7 +124,7 @@ os.environ["SERPAPI_API_KEY"] = os.getenv("SERPAPI_API_KEY")
 
 ``` python
 llm = OpenAI(model_name="text-davinci-003" ,temperature=0)
-tools = load_tools(["serpapi", "llm-math"], llm=llm)
+tools = load_tools(["google-serper", "llm-math"], llm=llm)
 agent = initialize_agent(tools, llm, agent="zero-shot-react-description", verbose=True)
 ```
 


### PR DESCRIPTION
Replaces `serpapi` with `google-serper` as the search tool for the ReAct Prompting notebook.
Serper API is a fast and low-cost Google Search API alternative to SerpAPI.
- approximately 2x lower latencies
- 10x cheaper
- more generous free tier (2,500 vs 100 free queries)

The [Serper integration with LangChain](https://python.langchain.com/en/latest/modules/agents/tools/examples/google_serper.html) also provides support for knowledge graph, people also ask and related searches data.

Developers can sign up for a free account at [serper.dev](https://serper.dev/) and obtain an api key.