### PR TITLE
Add prompted.link to tools.en.mdx

### DIFF
--- a/pages/tools.en.mdx
+++ b/pages/tools.en.mdx
@@ -39,6 +39,7 @@
 - [Prompt Engine](https://github.com/microsoft/prompt-engine)
 - [Prompt Generator for OpenAI's DALL-E 2](http://dalle2-prompt-generator.s3-website-us-west-2.amazonaws.com)
 - [Promptable](https://promptable.ai)
+- [prompted.link](https://prompted.link)
 - [PromptInject](https://github.com/agencyenterprise/PromptInject)
 - [Prompts.ai](https://github.com/sevazhidkov/prompts-ai)
 - [Promptmetheus](https://promptmetheus.com)


### PR DESCRIPTION
https://prompted.link is a web UI for editing and sharing LLM prompts with a simple pastebin-like approach, running the open source Prompter software (https://github.com/conversabile/prompter)

Disclosure: I wrote the software