### PR TITLE
Fix typo

### DIFF
--- a/pages/notebooks.kr.mdx
+++ b/pages/notebooks.kr.mdx
@@ -6,6 +6,6 @@
 | :------------ | :---------: | 
 |`openai` and `LangChain` 라이브러리를 사용하여 다양한 유형의 일반적인 작업을 수행하는 방법 알아보기|[Getting Started with Prompt Engineering](https://github.com/dair-ai/Prompt-Engineering-Guide/blob/main/notebooks/pe-lecture.ipynb)|
 |언어 모델과 함께 Python 인터프리터를 사용하여 일반적인 작업을 해결하기 위한 목적으로 코드를 사용하는 방법 알아보기.|[Program-Aided Language Model](https://github.com/dair-ai/Prompt-Engineering-Guide/blob/main/notebooks/pe-pal.ipynb)|
-|'openai` 라이브러리를 사용하여 ChatGPT API를 호출하는 방법에 대해 자세히 알아보기.|[ChatGPT API Intro](https://github.com/dair-ai/Prompt-Engineering-Guide/blob/main/notebooks/pe-chatgpt-intro.ipynb)|
+|`openai` 라이브러리를 사용하여 ChatGPT API를 호출하는 방법에 대해 자세히 알아보기.|[ChatGPT API Intro](https://github.com/dair-ai/Prompt-Engineering-Guide/blob/main/notebooks/pe-chatgpt-intro.ipynb)|
 |`LangChain` 라이브러리를 사용하여 ChatGPT 기능을 사용하는 방법 알아보기 |[ChatGPT API with LangChain](https://github.com/dair-ai/Prompt-Engineering-Guide/blob/main/notebooks/pe-chatgpt-langchain.ipynb)|
 |방어 조치(defensive measures)를 포함한 적대적(adversarial) 프롬프트에 대해 알아보기.|[Adversarial Prompt Engineering](https://github.com/dair-ai/Prompt-Engineering-Guide/blob/main/notebooks/pe-chatgpt-adversarial.ipynb)|


### PR DESCRIPTION
Hi, I corrected **simple typo** in the Korean [notebooks](https://www.promptingguide.ai/kr/notebooks) document.
'openai\` ->  `openai`
Thanks! ☺️