### PR TITLE
Adding a link to the crewAI framework

### DIFF
--- a/pages/research/llm-agents.en.mdx
+++ b/pages/research/llm-agents.en.mdx
@@ -131,6 +131,7 @@ Below are notable examples of tools and frameworks that are used to build LLM ag
 - [AgentVerse](https://github.com/OpenBMB/AgentVerse): designed to facilitate the deployment of multiple LLM-based agents in various applications. 
 - [Agents](https://github.com/aiwaves-cn/agents): an open-source library/framework for building autonomous language agents. The library supports features including long-short term memory, tool usage, web navigation, multi-agent communication, and brand new features including human-agent interaction and symbolic control.
 - [BMTools](https://github.com/OpenBMB/BMTools): extends language models using tools and serves as a platform for the community to build and share tools.
+- [crewAI](https://www.crewai.io/): AI agent framework reimagined for engineers, offering powerful capabilities with simplicity to build agents and automations.
 
 ## LLM Agent Evaluation
 


### PR DESCRIPTION
Added [crewAI](https://www.crewai.io/) - a streamlined AI agent framework for engineers, enabling easy creation of powerful agents and automations.
