### PR TITLE
Translated skipped occurrence word in Italian translation

### DIFF
--- a/pages/techniques/knowledge.it.mdx
+++ b/pages/techniques/knowledge.it.mdx
@@ -42,7 +42,7 @@ Input: Un effetto comune del fumare molte sigarette nel corso della vita è una 
 Conoscenza: Coloro che fumavano costantemente meno di una sigaretta al giorno nel corso della loro vita avevano un rischio nove volte superiore di morire di cancro ai polmoni rispetto ai non fumatori. Tra le persone che fumavano tra una e 10 sigarette al giorno, il rischio di morire di cancro ai polmoni era quasi 12 volte superiore a quello dei non fumatori.
 
 Input: Un sasso ha le stesse dimensioni di un sassolino.
-Knowledge: Un ciottolo è un frammento di roccia con una dimensione delle particelle compresa tra 4 e 64 millimetri secondo la scala Udden-Wentworth della sedimentologia. I ciottoli sono generalmente considerati più grandi dei granuli (da 2 a 4 millimetri di diametro) e più piccoli dei ciottoli (da 64 a 256 millimetri di diametro).
+Conoscenza: Un ciottolo è un frammento di roccia con una dimensione delle particelle compresa tra 4 e 64 millimetri secondo la scala Udden-Wentworth della sedimentologia. I ciottoli sono generalmente considerati più grandi dei granuli (da 2 a 4 millimetri di diametro) e più piccoli dei ciottoli (da 64 a 256 millimetri di diametro).
 
 Input: Una parte del golf consiste nel cercare di ottenere un totale di punti più alto degli altri.
 Conoscenza:


### PR DESCRIPTION
In that prompt, one occurrence of "Knowledge" wasn't translated into "Conoscenza" like the others.