### PR TITLE
add LoT paper in LLM reasoning approaches

### DIFF
--- a/pages/papers.en.mdx
+++ b/pages/papers.en.mdx
@@ -25,6 +25,8 @@ The following are the latest papers (sorted by release date) on prompt engineeri
 
 ## Approaches
 
+- [Enhancing Zero-Shot Chain-of-Thought Reasoning in Large Language Models through Logic
+](https://arxiv.org/abs/2309.13339) (February 2024)
 - [Principled Instructions Are All You Need for Questioning LLaMA-1/2, GPT-3.5/4
 ](https://arxiv.org/abs/2312.16171v1) (December 2023)
 - [Walking Down the Memory Maze: Beyond Context Limit through Interactive Reading](https://arxiv.org/abs/2310.05029) (October 2023)

--- a/pages/papers.zh.mdx
+++ b/pages/papers.zh.mdx
@@ -15,7 +15,9 @@
 
 ## 方法
 
-   - [Self-Refine: Iterative Refinement with Self-Feedback](https://arxiv.org/abs/2303.17651v1) (Mar 2023)
+  - [Enhancing Zero-Shot Chain-of-Thought Reasoning in Large Language Models through Logic
+  ](https://arxiv.org/abs/2309.13339) (February 2024)
+  - [Self-Refine: Iterative Refinement with Self-Feedback](https://arxiv.org/abs/2303.17651v1) (Mar 2023)
   - [kNN Prompting: Beyond-Context Learning with Calibration-Free Nearest Neighbor Inference](https://arxiv.org/abs/2303.13824) (Mar 2023)
   - [Visual-Language Prompt Tuning with Knowledge-guided Context Optimization](https://arxiv.org/abs/2303.13283) (Mar 2023)
   - [Fairness-guided Few-shot Prompting for Large Language Models](https://arxiv.org/abs/2303.13217) (Mar 2023)


### PR DESCRIPTION
Add the paper "Enhancing Zero-Shot Chain-of-Thought Reasoning in Large Language Models through Logic" (LoT for short, to appear at COLING 2024) in the LLM reasoning approaches part.