### PR TITLE
[Page] Update image path and description in RAG

### DIFF
--- a/pages/research/rag.en.mdx
+++ b/pages/research/rag.en.mdx
@@ -166,10 +166,10 @@ Some popular comprehensive tools to build RAG systems include [LangChain](https:
 
 ## Conclusion
 
-In conclusion, RAG systems have evolved rapidly including the development of more advanced paradigms that enable customization and further the performance and utility of RAG across a wide range of domains. There is a huge demand for RAG applications, which has accelerated the development of methods to improve the different components of a RAG system. From hybrid methodologies to self-retrieval, these are some of the currently explored research areas of modern RAG models. There is also increasing demand for better evaluation tools and metrics. The figure above provides a recap of the RAG ecosystem, techniques to enhance RAG, challenges, and other related aspects covered in this overview:
+In conclusion, RAG systems have evolved rapidly including the development of more advanced paradigms that enable customization and further the performance and utility of RAG across a wide range of domains. There is a huge demand for RAG applications, which has accelerated the development of methods to improve the different components of a RAG system. From hybrid methodologies to self-retrieval, these are some of the currently explored research areas of modern RAG models. There is also increasing demand for better evaluation tools and metrics. The figure below provides a recap of the RAG ecosystem, techniques to enhance RAG, challenges, and other related aspects covered in this overview:
 
 
-!["RAG Ecosystem"](../../img/rag/rag-metrics.png)
+!["RAG Ecosystem"](../../img/rag/rag-ecosystem.png)
 
 ---
 

--- a/pages/research/rag.en.mdx
+++ b/pages/research/rag.en.mdx
@@ -166,7 +166,7 @@ Some popular comprehensive tools to build RAG systems include [LangChain](https:
 
 ## Conclusion
 
-In conclusion, RAG systems have evolved rapidly including the development of more advanced paradigms that enable customization and further the performance and utility of RAG across a wide range of domains. There is a huge demand for RAG applications, which has accelerated the development of methods to improve the different components of a RAG system. From hybrid methodologies to self-retrieval, these are some of the currently explored research areas of modern RAG models. There is also increasing demand for better evaluation tools and metrics. The figure below provides a recap of the RAG ecosystem, techniques to enhance RAG, challenges, and other related aspects covered in this overview:
+In conclusion, RAG systems have evolved rapidly including the development of more advanced paradigms that enable customization and further the performance and utility of RAG across a wide range of domains. There is a huge demand for RAG applications, which has accelerated the development of methods to improve the different components of a RAG system. From hybrid methodologies to self-retrieval, these are some of the currently explored research areas of modern RAG models. There is also increasing demand for better evaluation tools and metrics. The figure below provides a recap of the RAG ecosystem, techniques to enhance RAG, challenges, and other related aspects covered in this overview:
 
 
 !["RAG Ecosystem"](../../img/rag/rag-ecosystem.png)


### PR DESCRIPTION
Hello, I've noticed a small issue in the documentation.

I've made the following changes:
- Updated the image path in the conclusion section from rag_metric to ecosystem.
- Changed the word "above" to "below" in the image description to accurately reflect the new image position.

Thank you for reviewing these changes.