### PR TITLE
Add Japanese translation for prompt_chaining

### DIFF
--- a/pages/techniques/prompt_chaining.jp.mdx
+++ b/pages/techniques/prompt_chaining.jp.mdx
@@ -1,3 +1,105 @@
 # Prompt Chaining
 
-This page needs a translation! Feel free to contribute a translation by clicking the `Edit this page` button on the right side.
+import {Screenshot} from 'components/screenshot'
+import PC1 from '../../img/prompt_chaining/prompt-chaining-1.png'
+
+## プロンプトチェイニングの紹介
+
+LLMの信頼性と性能を向上させるために、重要な手法の一つとして、タスクを複数のサブタスクに分割することがあります。これらのサブタスクが特定されると、LLMはそれぞれに対してプロンプトを出し、その回答を次のプロンプトの入力として利用します。これをプロンプト・チェイニングと呼び、タスクをサブタスクに分割してプロンプトの連鎖を作ることが目的です。
+
+この方法は、LLMが一度に扱うには複雑すぎる詳細なプロンプトに対処する際に有効です。プロンプトを連鎖させることで、望ましい最終結果に到達する前に、生成された応答に対して変更や追加の処理を行うことができます。プロンプトの連鎖はパフォーマンスを向上させるだけでなく、LLMアプリケーションの透明性を高め、より良い制御性と信頼性を実現するのに役立ちます。これにより、モデルの応答に関する問題を簡単にデバッグし、改善が必要な各段階のパフォーマンスを分析して改善することが可能になります。特に、LLMを使った会話アシスタントを構築し、アプリケーションのパーソナライズとユーザーエクスペリエンスを向上させる際にプロンプト・チェイニングは有効です。
+
+## プロンプト・チェイニングの使用例
+
+### ドキュメントQAのためのプロンプト・チェイニング
+
+プロンプト・チェイニングは、さまざまな操作や変換を伴うシナリオで利用可能です。例として、LLMの一般的な用途のひとつに、長い文章に基づいた質問に答えることがあります。
+ここで2つの異なるプロンプトを用意します。最初のプロンプトは、関連する引用を抽出して質問に答えるためのもので、次のプロンプトは、抽出された引用と元のドキュメントを使って質問に答えます。つまり、2つのステップを経て、ドキュメントにおける質問に対する回答を得ることが目的です。
+
+以下の最初のプロンプト例では、質問に基づいてドキュメントから関連する引用を抽出するよう設計されています。簡潔さを保つために、文書のプレースホルダーを設定しています。このプロンプトを試す場合は、ウィキペディアの記事をコピー＆ペーストし、このページで[プロンプトエンジニアリング](https://en.wikipedia.org/wiki/Prompt_engineering)を適用してみてください（このタスクには広範なコンテキストが必要なため、OpenAIの`gpt-4-1106-preview`モデルを使用します）。このプロンプトは、Claudeのような長いコンテキストを扱うLLMでも使用可能です。
+
+プロンプト1：
+```
+あなたは親切なアシスタントです。
+あなたの仕事は、文書で与えられた質問に答えるのを助けることです。最初のステップは、####で区切られた文書から質問に関連する引用を抽出することです。
+引用のリストは<quotes></quotes>を使って出力してください。関連する引用が見つからなかった場合は「関連する引用は見つかりませんでした。]と返信してください。
+####
+{{document}}
+####
+```
+
+これは、`user`のroleを使用して渡される質問を含むプロンプト全体のスクリーンショットです。
+
+<Screenshot src={PC1} alt="Prompt Chaining Part 1" />
+
+Output of Prompt 1:
+```
+<quotes>
+- Chain-of-thought (CoT) prompting[27]
+- Generated knowledge prompting[37]
+- Least-to-most prompting[38]
+- Self-consistency decoding[39]
+- Complexity-based prompting[41]
+- Self-refine[42]
+- Tree-of-thought prompting[43]
+- Maieutic prompting[45]
+- Directional-stimulus prompting[46]
+- Textual inversion and embeddings[59]
+- Using gradient descent to search for prompts[61][62][63][64]
+- Prompt injection[65][66][67]
+</quotes>
+```
+
+最初のプロンプトで得られた引用は、次に示す2番目のプロンプトの入力として使用できます。引用をもう少し整理することもできます。つまり、引用部分から出典を取り除くことが可能です。これらの出典は削除するか、別のプロンプトの一部として活用することができますが、現段階では無視しても構いません。
+
+次に、2番目のプロンプトは、プロンプト1で抽出された関連する引用を取り、文書で提起された質問と抽出された引用に対して有益な回答を準備します。
+
+2番目のプロンプトは以下のようになります：
+```
+ある文書から抽出された関連する引用（<quotes></quotes>で区切られています）と元の文書（###で区切られています）が与えられたら、質問に対する答えを作成してください。
+回答は正確で、友好的な口調で、役に立つように聞こえるようにしてください。
+
+####
+{{document}}
+####
+
+<quotes>
+- Chain-of-thought (CoT) prompting[27]
+- Generated knowledge prompting[37]
+- Least-to-most prompting[38]
+- Self-consistency decoding[39]
+- Complexity-based prompting[41]
+- Self-refine[42]
+- Tree-of-thought prompting[43]
+- Maieutic prompting[45]
+- Directional-stimulus prompting[46]
+- Textual inversion and embeddings[59]
+- Using gradient descent to search for prompts[61][62][63][64]
+- Prompt injection[65][66][67]
+</quotes>
+```
+
+Output of Prompt 2:
+
+```
+文書で言及されているプロンプトのテクニックには、以下のようなものがある：
+
+1. Chain-of-thought (CoT) prompting[27]
+2. Generated knowledge prompting[37]
+3. Least-to-most prompting[38]
+4. Self-consistency decoding[39]
+5. Complexity-based prompting[41]
+6. Self-refine[42]
+7. Tree-of-thought prompting[43]
+8. Maieutic prompting[45]
+9. Directional-stimulus prompting[46]
+10. Textual inversion and embeddings[59]
+11. Using gradient descent to search for prompts[61][62][63][64]
+12. Prompt injection[65][66][67]
+
+これらの技法はそれぞれ、大規模な言語モデルとの相互作用を強化したり特定したりして、望ましい結果を生み出すための独自の戦略を採用している。
+```
+
+おわかりのように、プロンプトチェーンを簡略化して作成することは、応答 がいくつかの操作や変換を受ける必要がある場合に有効なプロンプトアプローチである。練習として、アプリケーションのユーザーに最終的なレスポンスとして送信する前に、レスポンスから引用 (例: 27) を削除するプロンプトを自由に設計してください。
+
+プロンプトチェイニングの例は、こちらの [documentation](https://docs.anthropic.com/claude/docs/prompt-chaining) ( Claude LLMを活用しています)にもあります。私たちの例は彼らの例からヒントを得てアレンジしたものです。


### PR DESCRIPTION
 [Update prompt_chaining.jp.mdx]

This commit adds the Japanese translation for the documentation on prompt chaining.  The file updated is `prompt_chaining.jp.mdx`, ensuring the content is accessible to Japanese-speaking developers and users. This translation aims to enhance understanding and usage of prompt chaining techniques within the Japanese developer community.