### PR TITLE
Change "idioma" to "linguagem" in examples.pt

### DIFF
--- a/pages/introduction/examples.pt.mdx
+++ b/pages/introduction/examples.pt.mdx
@@ -214,7 +214,7 @@ let name = prompt("Qual é o seu nome?");
 console.log(`Olá, ${name}!`);
 ```
 
-Você pode ver que nem precisamos especificar o idioma a ser usado.
+Você pode ver que nem precisamos especificar a linguagem a ser usada.
 
 Vamos mudar um pouco os níveis. Quero mostrar a você como os LLMs podem ser poderosos com um pouco mais de esforço no design dos prompts.
 


### PR DESCRIPTION
"Linguagem", in this context, refers to a programming language, while "idioma" refers to a regular language.

Wikipedia's portuguese page for programming language has no mention for "idioma", for example: https://pt.wikipedia.org/wiki/Linguagem_de_programa%C3%A7%C3%A3o