### PR TITLE
Remove `<Bleed>` Tag to fix videos from overlaying the sidebar

### DIFF
--- a/pages/introduction/basics.de.mdx
+++ b/pages/introduction/basics.de.mdx
@@ -27,13 +27,11 @@ Wenn Sie den OpenAI Playground oder einen anderen Playground verwenden, dann kö
 
 Hier ist eine Anleitung, wie man mit dem OpenAI Playground beginnen kann:
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/iwYtzPJELkk?si=irua5h_wHrkNCY0V" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/iwYtzPJELkk?si=irua5h_wHrkNCY0V" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />
 
 
 Zu beachten ist, dass man bei der Verwendung der OpenAI-Chatmodelle wie `gtp-3.5-turbo` oder `gpt-4` die Struktur des Prompts mit drei verschiedenen Rollen gestalten kann: `system`, `user` und `assistant`. Eine Eingabe mit `system` ist nicht erforderlich, hilft aber, das Gesamtverhalten des Assistenten festzulegen. Das obige Beispiel beinhaltet nur eine Nutzernachricht, mit der man das Modell direkt auffordern kann. Zur Vereinfachung wird in allen Beispielen, außer es ist ausdrücklich erwähnt, nur die `user`-Nachricht verwendet, um das `gtp-3.5-turbo` Modell zu prompten. Die `assistant`-Nachricht im obigen Beispiel entspricht der Modellantwort. Man kann auch eine Assistentennachricht definieren, um Beispiele für das gewünschte Verhalten zu übermitteln, das man erreichen möchte. Mehr über das Arbeiten mit Chatmodellen kann man [hier](https://www.promptingguide.ai/models/chatgpt) erfahren.

--- a/pages/introduction/basics.en.mdx
+++ b/pages/introduction/basics.en.mdx
@@ -27,13 +27,11 @@ If you are using the OpenAI Playground or any other LLM playground, you can prom
 
 Here is a tutorial on how to get started with the OpenAI Playground:
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/iwYtzPJELkk?si=irua5h_wHrkNCY0V" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/iwYtzPJELkk?si=irua5h_wHrkNCY0V" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />
 
 
 Something to note is that when using the OpenAI chat models like `gpt-3.5-turbo` or `gpt-4`, you can structure your prompt using three different roles: `system`, `user`, and `assistant`. The system message is not required but helps to set the overall behavior of the assistant. The example above only includes a user message which you can use to directly prompt the model. For simplicity, all of the examples, except when it's explicitly mentioned, will use only the `user` message to prompt the `gpt-3.5-turbo` model. The `assistant` message in the example above corresponds to the model response. You can also define an assistant message to pass examples of the desired behavior you want. You can learn more about working with chat models [here](https://www.promptingguide.ai/models/chatgpt).

--- a/pages/introduction/elements.de.mdx
+++ b/pages/introduction/elements.de.mdx
@@ -14,13 +14,11 @@ Ein Prompt enthält eines oder mehrere der folgenden Elemente:
 
 **Ausgabeindikator** - die Art oder das Format der Ausgabe.
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/kgBZhJnh-vk?si=-a-KvhmXFJMtAuCB" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/kgBZhJnh-vk?si=-a-KvhmXFJMtAuCB" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />
 
 Um die Elemente eines Prompts besser zu demonstrieren, hier ein einfaches Beispiel, das darauf abzielt, eine Textklassifizierungsaufgabe durchzuführen:
 

--- a/pages/introduction/elements.en.mdx
+++ b/pages/introduction/elements.en.mdx
@@ -14,13 +14,11 @@ A prompt contains any of the following elements:
 
 **Output Indicator** - the type or format of the output.
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/kgBZhJnh-vk?si=-a-KvhmXFJMtAuCB" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/kgBZhJnh-vk?si=-a-KvhmXFJMtAuCB" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />
 
 To demonstrate the prompt elements better, here is a simple prompt that aims to perform a text classification task:
 

--- a/pages/introduction/examples.en.mdx
+++ b/pages/introduction/examples.en.mdx
@@ -19,13 +19,11 @@ Topics:
 
 ---
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/TBhRC4Dath4?si=6nwh0GuYAOv1H6yT" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/TBhRC4Dath4?si=6nwh0GuYAOv1H6yT" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />
 
 ## Text Summarization
 One of the standard tasks in natural language generation is text summarization. Text summarization can include many different flavors and domains. In fact, one of the most promising applications of language models is the ability to summarize articles and concepts into quick and easy-to-read summaries. Let's try a basic summarization task using prompts.

--- a/pages/introduction/settings.de.mdx
+++ b/pages/introduction/settings.de.mdx
@@ -2,13 +2,11 @@
 
 import {Bleed} from 'nextra-theme-docs'
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/CB0H7esOl68?si=OECAnvgnvJHy0qZ2" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/CB0H7esOl68?si=OECAnvgnvJHy0qZ2" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />
 
 Beim Entwerfen und Testen von Prompts interagieren Sie normalerweise über eine API mit dem LLM. Sie können einige Parameter konfigurieren, um unterschiedliche Ergebnisse für Ihre Prompts zu erhalten. Das Anpassen dieser Einstellungen ist wichtig, um die Zuverlässigkeit und Erwünschtheit der Antworten zu verbessern, und es bedarf des Experimentierens, um die richtigen Einstellungen für Ihre Anwendungsfälle herauszufinden. Unten finden Sie die gängigen Einstellungen, auf die Sie bei der Verwendung verschiedener LLM-Anbieter stoßen werden:
 

--- a/pages/introduction/settings.en.mdx
+++ b/pages/introduction/settings.en.mdx
@@ -2,13 +2,11 @@
 
 import {Bleed} from 'nextra-theme-docs'
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/CB0H7esOl68?si=OECAnvgnvJHy0qZ2" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/CB0H7esOl68?si=OECAnvgnvJHy0qZ2" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />
 
 When designing and testing prompts, you typically interact with the LLM via an API. You can configure a few parameters to get different results for your prompts. Tweaking these settings are important to improve reliability and desirability of responses and it takes  a bit of experimentation to figure out the proper settings for your use cases. Below are the common settings you will come across when using different LLM providers:
 

--- a/pages/introduction/tips.de.mdx
+++ b/pages/introduction/tips.de.mdx
@@ -2,13 +2,11 @@
 
 import {Bleed} from 'nextra-theme-docs'
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/7M6CSCIMJ3k?si=BgaVt9g1vS4BQzXZ" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/7M6CSCIMJ3k?si=BgaVt9g1vS4BQzXZ" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />
 
 Hier sind einige Tipps, die Sie beim Entwerfen Ihrer Prompts im Kopf behalten sollten:
 

--- a/pages/introduction/tips.en.mdx
+++ b/pages/introduction/tips.en.mdx
@@ -2,13 +2,11 @@
 
 import {Bleed} from 'nextra-theme-docs'
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/7M6CSCIMJ3k?si=BgaVt9g1vS4BQzXZ" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/7M6CSCIMJ3k?si=BgaVt9g1vS4BQzXZ" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />
 
 Here are some tips to keep in mind while you are designing your prompts:
 

--- a/pages/models/llama-3.de.mdx
+++ b/pages/models/llama-3.de.mdx
@@ -40,10 +40,8 @@ Die Lizenzinformationen für die Llama 3 Modelle können auf der [Modellkarte](h
 
 Hier folgt eine längere Bewertung von Llama 3:
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/h2aEmciRd6U?si=m7-xXu5IWpB-6mE0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/h2aEmciRd6U?si=m7-xXu5IWpB-6mE0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />

--- a/pages/models/llama-3.en.mdx
+++ b/pages/models/llama-3.en.mdx
@@ -40,10 +40,8 @@ The licensing information for the Llama 3 models can be found on the [model card
 
 Here is a longer review of Llama 3:
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/h2aEmciRd6U?si=m7-xXu5IWpB-6mE0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/h2aEmciRd6U?si=m7-xXu5IWpB-6mE0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />

--- a/pages/models/sora.de.mdx
+++ b/pages/models/sora.de.mdx
@@ -15,14 +15,12 @@ Prompt:
 Eine stilvolle Frau geht eine Tokioter Straße entlang, die von warm leuchtenden Neonlichtern und animierter Stadtschilderung erfüllt ist. Sie trägt eine schwarze Lederjacke, ein langes rotes Kleid und schwarze Stiefel und hat eine schwarze Handtasche dabei. Sie trägt Sonnenbrille und roten Lippenstift. Sie geht selbstbewusst und locker. Die Straße ist feucht und spiegelnd, wodurch ein Spiegeleffekt der bunten Lichter entsteht. Viele Fußgänger gehen umher.
 ```
 
-<Bleed >
-  <iframe
-    src="https://cdn.openai.com/sora/videos/tokyo-walk.mp4"
-    width="100%"
-    height="300px"
-    title="SWR-States"
-  />
-</Bleed>
+<iframe
+  src="https://cdn.openai.com/sora/videos/tokyo-walk.mp4"
+  width="100%"
+  height="300px"
+  title="SWR-States"
+/>
 
 Prompt:
 
@@ -30,14 +28,12 @@ Prompt:
 Ein Filmtrailer, der die Abenteuer des 30-jährigen Raumfahrers zeigt, der einen roten Woll- gestrickten Motorradhelm trägt, blauer Himmel, Salzwüste, kinematografischer Stil, auf 35mm Film gedreht, leuchtende Farben.
 ```
 
-<Bleed >
-  <iframe
-    src="https://cdn.openai.com/sora/videos/mitten-astronaut.mp4"
-    width="100%"
-    height="300px"
-    title="SWR-States"
-  />
-</Bleed>
+<iframe
+  src="https://cdn.openai.com/sora/videos/mitten-astronaut.mp4"
+  width="100%"
+  height="300px"
+  title="SWR-States"
+/>
 
 *Videoquelle: https://openai.com/sora*
 
@@ -54,14 +50,12 @@ Prompt:
 Szene im Schritt-Druck-Verfahren einer rennenden Person, kinematografische Filmaufnahme in 35mm.
 ```
 
-<Bleed >
-  <iframe
-    src="https://cdn.openai.com/sora/videos/backward-jogger.mp4"
-    width="100%"
-    height="300px"
-    title="SWR-States"
-  />
-</Bleed>
+<iframe
+  src="https://cdn.openai.com/sora/videos/backward-jogger.mp4"
+  width="100%"
+  height="300px"
+  title="SWR-States"
+/>
 
 *Videoquelle: https://openai.com/sora*
 

--- a/pages/models/sora.en.mdx
+++ b/pages/models/sora.en.mdx
@@ -15,14 +15,12 @@ Prompt:
 A stylish woman walks down a Tokyo street filled with warm glowing neon and animated city signage. She wears a black leather jacket, a long red dress, and black boots, and carries a black purse. She wears sunglasses and red lipstick. She walks confidently and casually. The street is damp and reflective, creating a mirror effect of the colorful lights. Many pedestrians walk about.
 ```
 
-<Bleed >
-  <iframe
-    src="https://cdn.openai.com/sora/videos/tokyo-walk.mp4"
-    width="100%"
-    height="300px"
-    title="SWR-States"
-  />
-</Bleed>
+<iframe
+  src="https://cdn.openai.com/sora/videos/tokyo-walk.mp4"
+  width="100%"
+  height="300px"
+  title="SWR-States"
+/>
 
 Prompt:
 
@@ -30,14 +28,12 @@ Prompt:
 A movie trailer featuring the adventures of the 30 year old space man wearing a red wool knitted motorcycle helmet, blue sky, salt desert, cinematic style, shot on 35mm film, vivid colors.
 ```
 
-<Bleed >
-  <iframe
-    src="https://cdn.openai.com/sora/videos/mitten-astronaut.mp4"
-    width="100%"
-    height="300px"
-    title="SWR-States"
-  />
-</Bleed>
+<iframe
+  src="https://cdn.openai.com/sora/videos/mitten-astronaut.mp4"
+  width="100%"
+  height="300px"
+  title="SWR-States"
+/>
 
 *Video source: https://openai.com/sora*
 
@@ -54,14 +50,12 @@ Prompt:
 Prompt: Step-printing scene of a person running, cinematic film shot in 35mm.
 ```
 
-<Bleed >
-  <iframe
-    src="https://cdn.openai.com/sora/videos/backward-jogger.mp4"
-    width="100%"
-    height="300px"
-    title="SWR-States"
-  />
-</Bleed>
+<iframe
+  src="https://cdn.openai.com/sora/videos/backward-jogger.mp4"
+  width="100%"
+  height="300px"
+  title="SWR-States"
+/>
 
 *Video source: https://openai.com/sora*
 

--- a/pages/models/sora.jp.mdx
+++ b/pages/models/sora.jp.mdx
@@ -16,14 +16,12 @@ Prompt:
 スタイリッシュな女性が、暖かく光るネオンとアニメーションの街の看板で満ちた東京の通りを歩いています。彼女は黒のレザージャケット、長い赤いドレス、黒いブーツを着用し、黒いハンドバッグを持っています。サングラスと赤いリップスティックを身につけています。彼女は自信を持って、そしてカジュアルに歩きます。通りは湿っており、反射して、カラフルな光のミラー効果を生み出しています。多くの歩行者が歩いています。
 ```
 
-<Bleed>
-  <iframe
-    src="https://cdn.openai.com/sora/videos/tokyo-walk.mp4"
-    width="100%"
-    height="300px"
-    title="SWR-States"
-  />
-</Bleed>
+<iframe
+  src="https://cdn.openai.com/sora/videos/tokyo-walk.mp4"
+  width="100%"
+  height="300px"
+  title="SWR-States"
+/>
 
 Prompt:
 
@@ -31,14 +29,12 @@ Prompt:
 30歳の宇宙飛行士の冒険を描いた映画の予告編で、赤いウールの編み込みモーターサイクルヘルメットを着用し、青空、塩の砂漠、シネマティックスタイル、35mmフィルムで撮影され、鮮やかな色彩。
 ```
 
-<Bleed>
-  <iframe
-    src="https://cdn.openai.com/sora/videos/mitten-astronaut.mp4"
-    width="100%"
-    height="300px"
-    title="SWR-States"
-  />
-</Bleed>
+<iframe
+  src="https://cdn.openai.com/sora/videos/mitten-astronaut.mp4"
+  width="100%"
+  height="300px"
+  title="SWR-States"
+/>
 
 _Video source: https://openai.com/sora_
 
@@ -56,14 +52,12 @@ Prompt:
 プロンプト：35mmの映画フィルムで撮影された、走る人物のステッププリントシーン。
 ```
 
-<Bleed>
-  <iframe
-    src="https://cdn.openai.com/sora/videos/backward-jogger.mp4"
-    width="100%"
-    height="300px"
-    title="SWR-States"
-  />
-</Bleed>
+<iframe
+  src="https://cdn.openai.com/sora/videos/backward-jogger.mp4"
+  width="100%"
+  height="300px"
+  title="SWR-States"
+/>
 
 _Video source: https://openai.com/sora_
 

--- a/pages/research/guided-cot.en.mdx
+++ b/pages/research/guided-cot.en.mdx
@@ -2,13 +2,11 @@
 
 import {Bleed} from 'nextra-theme-docs'
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/O3bl0qURONM?si=Hwdc_o0qHpw8QRsY" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/O3bl0qURONM?si=Hwdc_o0qHpw8QRsY" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />
 
 A new paper by [Lee et al. (2024)](https://arxiv.org/abs/2404.03414) proposes to improve reasoning in LLMs using small language models.
 

--- a/pages/research/infini-attention.de.mdx
+++ b/pages/research/infini-attention.de.mdx
@@ -2,13 +2,11 @@
 
 import {Bleed} from 'nextra-theme-docs'
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/tOaTaQ8ZGRo?si=pFP-KiLe63Ppl9Pd" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/tOaTaQ8ZGRo?si=pFP-KiLe63Ppl9Pd" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />
 
 Ein neues [Paper](https://arxiv.org/abs/2404.07143) von Google integriert kompressiven Speicher in eine Vanilla Dot-Product Attention-Schicht.
 

--- a/pages/research/infini-attention.en.mdx
+++ b/pages/research/infini-attention.en.mdx
@@ -2,13 +2,11 @@
 
 import {Bleed} from 'nextra-theme-docs'
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/tOaTaQ8ZGRo?si=pFP-KiLe63Ppl9Pd" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/tOaTaQ8ZGRo?si=pFP-KiLe63Ppl9Pd" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />
 
 A new [paper](https://arxiv.org/abs/2404.07143) by Google integrates compressive memory into a vanilla dot-product attention layer. 
 

--- a/pages/research/llm-recall.de.mdx
+++ b/pages/research/llm-recall.de.mdx
@@ -2,13 +2,11 @@
 
 import {Bleed} from 'nextra-theme-docs'
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/2cNO76lIZ4s?si=tbbdo-vnr56YQ077" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/2cNO76lIZ4s?si=tbbdo-vnr56YQ077" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />
 
 Dieses neue [Paper von Machlab und Battle (2024)](https://arxiv.org/abs/2404.08865) analysiert die In-Context Recall-Leistung verschiedener LLMs anhand mehrerer Nadel-im-Heuhaufen-Tests.
 

--- a/pages/research/llm-recall.en.mdx
+++ b/pages/research/llm-recall.en.mdx
@@ -2,13 +2,11 @@
 
 import {Bleed} from 'nextra-theme-docs'
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/2cNO76lIZ4s?si=tbbdo-vnr56YQ077" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/2cNO76lIZ4s?si=tbbdo-vnr56YQ077" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />
 
 This new [paper by Machlab and Battle (2024)](https://arxiv.org/abs/2404.08865) analyzes the in-context recall performance of different LLMs using several needle-in-a-haystack tests.
 

--- a/pages/research/rag-faithfulness.de.mdx
+++ b/pages/research/rag-faithfulness.de.mdx
@@ -2,13 +2,11 @@
 
 import {Bleed} from 'nextra-theme-docs'
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/eEU1dWVE8QQ?si=b-qgCU8nibBCSX8H" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/eEU1dWVE8QQ?si=b-qgCU8nibBCSX8H" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />
 
 Dieses neue Paper von [Wu et al. (2024)](https://arxiv.org/abs/2404.10198) zielt darauf ab, das Kräftemessen zwischen den RAG-Modellen und der internen Priorisierung von LLMs zu quantifizieren.
 

--- a/pages/research/rag-faithfulness.en.mdx
+++ b/pages/research/rag-faithfulness.en.mdx
@@ -2,13 +2,11 @@
 
 import {Bleed} from 'nextra-theme-docs'
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/eEU1dWVE8QQ?si=b-qgCU8nibBCSX8H" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/eEU1dWVE8QQ?si=b-qgCU8nibBCSX8H" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />
 
 This new paper by [Wu et al. (2024)](https://arxiv.org/abs/2404.10198) aims to quantify the tug-of-war between RAG and LLMs' internal prior.  
 

--- a/pages/research/rag_hallucinations.en.mdx
+++ b/pages/research/rag_hallucinations.en.mdx
@@ -2,13 +2,11 @@
 
 import {Bleed} from 'nextra-theme-docs'
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/TUL5guqZejw?si=Doc7lzyAY-SKr21L" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/TUL5guqZejw?si=Doc7lzyAY-SKr21L" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />
 
 Researchers at ServiceNow shared a [new paper](https://arxiv.org/abs/2404.08189) where they discuss how to deploy an efficient RAG system for structured output tasks.
 

--- a/pages/research/synthetic_data.en.mdx
+++ b/pages/research/synthetic_data.en.mdx
@@ -2,13 +2,11 @@
 
 import {Bleed} from 'nextra-theme-docs'
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/YnlArBZJHY8?si=ZH3hFzwixUopxU5Z" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/YnlArBZJHY8?si=ZH3hFzwixUopxU5Z" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />
 
 This [paper](https://arxiv.org/abs/2404.07503) provides an overview of best practices and lessons learned on synthetic data for language models ans was published by Google DeepMind and other collaborators. 
 

--- a/pages/research/thoughtsculpt.de.mdx
+++ b/pages/research/thoughtsculpt.de.mdx
@@ -2,13 +2,11 @@
 
 import {Bleed} from 'nextra-theme-docs'
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/13fr5m6ezOM?si=DH3XYfzbMsg9aeIx" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/13fr5m6ezOM?si=DH3XYfzbMsg9aeIx" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />
 
 Diese Arbeit von [Chi et al. (2024)](https://arxiv.org/abs/2404.05966) stellt einen Ansatz für allgemeines Überlegen und Suchen bei Aufgaben vor, die in Komponenten zerlegt werden können.
 

--- a/pages/research/thoughtsculpt.en.mdx
+++ b/pages/research/thoughtsculpt.en.mdx
@@ -2,13 +2,11 @@
 
 import {Bleed} from 'nextra-theme-docs'
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/13fr5m6ezOM?si=DH3XYfzbMsg9aeIx" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/13fr5m6ezOM?si=DH3XYfzbMsg9aeIx" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />
 
 This work by [Chi et al. (2024)](https://arxiv.org/abs/2404.05966) presents an approach for general reasoning and search on tasks that can be decomposed into components. 
 

--- a/pages/techniques/zeroshot.de.mdx
+++ b/pages/techniques/zeroshot.de.mdx
@@ -2,13 +2,11 @@
 
 import {Bleed} from 'nextra-theme-docs'
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/ZTaHqdkxUMs?si=EDLjgAxuFxFcrSM3" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/ZTaHqdkxUMs?si=EDLjgAxuFxFcrSM3" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />
 
 Große LLMs (Language-Modelle) wie beispielsweise GPT-3.5 Turbo, GPT-4 und Claude 3 sind heute darauf abgestimmt, Anweisungen zu befolgen, und wurden mit großen Datenmengen trainiert. Groß angelegtes Training ermöglicht es diesen Modellen, einige Aufgaben auf
  "Zero-Shot"-Weise auszuführen. Zero-Shot-Prompting bedeutet, dass der Prompt, der verwendet wird, um mit dem Modell zu interagieren, keine Beispiele oder Demonstrationen enthält. Der Zero-Shot-Prompt instruiert das Modell direkt, eine Aufgabe ohne zusätzliche Beispiele auszuführen, um es zu lenken.

--- a/pages/techniques/zeroshot.en.mdx
+++ b/pages/techniques/zeroshot.en.mdx
@@ -2,13 +2,11 @@
 
 import {Bleed} from 'nextra-theme-docs'
 
-<Bleed>
-  <iframe width="100%"
-    height="415px"
-    src="https://www.youtube.com/embed/ZTaHqdkxUMs?si=EDLjgAxuFxFcrSM3" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    />
-</Bleed>
+<iframe width="100%"
+  height="415px"
+  src="https://www.youtube.com/embed/ZTaHqdkxUMs?si=EDLjgAxuFxFcrSM3" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  />
 
 Large language models (LLMs) today, such as GPT-3.5 Turbo, GPT-4, and Claude 3, are tuned to follow instructions and are trained on large amounts of data. Large-scale training makes these models capable of performing some tasks in a "zero-shot" manner. Zero-shot prompting means that the prompt used to interact with the model won't contain examples or demonstrations. The zero-shot prompt directly instructs the model to perform a task without any additional examples to steer it.
 


### PR DESCRIPTION
Removed all occurences of the `<Bleed>` tag since it was a bit in the way and covering the sidebar, here are screenshots of before and after:

**BEFORE**:
![image](https://github.com/dair-ai/Prompt-Engineering-Guide/assets/70029024/3a8272b7-294e-461a-b049-183ddda18a62)

**AFTER**:
![image](https://github.com/dair-ai/Prompt-Engineering-Guide/assets/70029024/12ab8bee-08ed-44d5-8852-3d52ee44fce1)
