### PR TITLE
docs: update knowledge.pt.mdx

### DIFF
--- a/pages/techniques/knowledge.pt.mdx
+++ b/pages/techniques/knowledge.pt.mdx
@@ -89,4 +89,4 @@ Explique e responda:
 Sim, parte do golfe é tentar obter um total de pontos mais alto do que outros. Cada jogador tenta completar o percurso com a menor pontuação, que é calculada somando o total número de tacadas dadas em cada buraco. O jogador com a pontuação mais baixa ganha o jogo.
 ```
 
-Algumas coisas realmente interessantes aconteceram com este exemplo. Na primeira resposta a modelo estava muito confiante mas na segunda nem tanto. Simplifiquei o processo para fins de demonstração, mas há mais alguns detalhes a serem considerados ao chegar à resposta final. Confira o papel para mais.
+Algumas coisas realmente interessantes aconteceram com este exemplo. Na primeira resposta a modelo estava muito confiante mas na segunda nem tanto. Simplifiquei o processo para fins de demonstração, mas há mais alguns detalhes a serem considerados ao chegar à resposta final. Confira o artigo para mais.


### PR DESCRIPTION
In this context, 'paper' refers to a published academic article or research paper, while 'papel' refers to a physical sheet of paper.

By replacing "papel" with "artigo" you ensure that the reader understands the specific type of written work being referred to and maintain the appropriate level of formality for the context.

Wikipedia's portuguese for Scientific Papers has no mention to 'papel' for example:
https://pt.wikipedia.org/wiki/Artigo_cient%C3%ADfico