### PR TITLE
fix: Elimination of unnecessary space

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -36,7 +36,7 @@ const config: DocsThemeConfig = {
     const { title } = useConfig()
     return (
     <>
-      <title>{title ? title + ' | Prompt Engineering Guide': 'Prompt Engineering Guide'} </title>
+      <title>{title ? title + ' | Prompt Engineering Guide': 'Prompt Engineering Guide'}</title>
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <meta property="og:title" content="Prompt Engineering Guide" />
       <meta property="og:description" content="A Comprehensive Overview of Prompt Engineering" />


### PR DESCRIPTION
A warning is displayed when multiple nodes are passed even though only one node can be under a `<title>` tag.

```
Warning: A title element received an array with more than 1 element as children. In browsers title Elements can only have Text Nodes as children. If the children being rendered output more than a single text node in aggregate the browser will display markup and comments as text in the title and hydration will likely fail and fall back to client rendering
    at title
    at head
    at Head (webpack-internal:///./node_modules/.pnpm/next@13.5.6_@babel+core@7.23.7_react-dom@18.2.0_react@18.2.0__react@18.2.0/node_modules/next/dist/pages/_document.js:258:1)
    at html
    at Html (webpack-internal:///./node_modules/.pnpm/next@13.5.6_@babel+core@7.23.7_react-dom@18.2.0_react@18.2.0__react@18.2.0/node_modules/next/dist/pages/_document.js:676:132)
    at Document (webpack-internal:///./node_modules/.pnpm/next@13.5.6_@babel+core@7.23.7_react-dom@18.2.0_react@18.2.0__react@18.2.0/node_modules/next/dist/pages/_document.js:692:1)
```
ref: https://github.com/vercel/next.js/discussions/38256

If there is an extra blank space at the end of the title, it is assumed to be recognized as a separate node.
By removing the blank space, this error no longer appears.