### PR TITLE
Add ChainForge to `tools` list

### DIFF
--- a/ar-pages/tools.ar.mdx
+++ b/ar-pages/tools.ar.mdx
@@ -8,6 +8,7 @@
 - [AnySolve](https://www.anysolve.ai)
 - [AnythingLLM](https://github.com/Mintplex-Labs/anything-llm)
 - [betterprompt](https://github.com/stjordanis/betterprompt)
+- [ChainForge](https://github.com/ianarawjo/ChainForge)
 - [Chainlit](https://github.com/chainlit/chainlit)
 - [ChatGPT Prompt Generator](https://huggingface.co/spaces/merve/ChatGPT-prompt-generator)
 - [ClickPrompt](https://github.com/prompt-engineering/click-prompt)

--- a/pages/tools.en.mdx
+++ b/pages/tools.en.mdx
@@ -8,7 +8,7 @@
 - [AnySolve](https://www.anysolve.ai)
 - [AnythingLLM](https://github.com/Mintplex-Labs/anything-llm)
 - [betterprompt](https://github.com/stjordanis/betterprompt)
-- [ChainForge(https://github.com/ianarawjo/ChainForge)
+- [ChainForge](https://github.com/ianarawjo/ChainForge)
 - [Chainlit](https://github.com/chainlit/chainlit)
 - [ChatGPT Prompt Generator](https://huggingface.co/spaces/merve/ChatGPT-prompt-generator)
 - [ClickPrompt](https://github.com/prompt-engineering/click-prompt)

--- a/pages/tools.en.mdx
+++ b/pages/tools.en.mdx
@@ -8,6 +8,7 @@
 - [AnySolve](https://www.anysolve.ai)
 - [AnythingLLM](https://github.com/Mintplex-Labs/anything-llm)
 - [betterprompt](https://github.com/stjordanis/betterprompt)
+- [ChainForge(https://github.com/ianarawjo/ChainForge)
 - [Chainlit](https://github.com/chainlit/chainlit)
 - [ChatGPT Prompt Generator](https://huggingface.co/spaces/merve/ChatGPT-prompt-generator)
 - [ClickPrompt](https://github.com/prompt-engineering/click-prompt)

--- a/pages/tools.es.mdx
+++ b/pages/tools.es.mdx
@@ -6,6 +6,7 @@
 - [Agenta](https://github.com/Agenta-AI/agenta)
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [betterprompt](https://github.com/stjordanis/betterprompt)
+- [ChainForge](https://github.com/ianarawjo/ChainForge)
 - [Chainlit](https://github.com/chainlit/chainlit)
 - [ChatGPT Prompt Generator](https://huggingface.co/spaces/merve/ChatGPT-prompt-generator)
 - [ClickPrompt](https://github.com/prompt-engineering/click-prompt)

--- a/pages/tools.fi.mdx
+++ b/pages/tools.fi.mdx
@@ -6,6 +6,7 @@
 - [Agenta](https://github.com/Agenta-AI/agenta)
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [betterprompt](https://github.com/krrishdholakia/betterprompt)
+- [ChainForge](https://github.com/ianarawjo/ChainForge)
 - [Chainlit](https://github.com/chainlit/chainlit)
 - [ChatGPT Prompt Generator](https://huggingface.co/spaces/merve/ChatGPT-prompt-generator)
 - [ClickPrompt](https://github.com/prompt-engineering/click-prompt)

--- a/pages/tools.fr.mdx
+++ b/pages/tools.fr.mdx
@@ -6,6 +6,7 @@
 - [Agenta](https://github.com/Agenta-AI/agenta)
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [betterprompt](https://github.com/stjordanis/betterprompt)
+- [ChainForge](https://github.com/ianarawjo/ChainForge)
 - [Chainlit](https://github.com/chainlit/chainlit)
 - [ChatGPT Prompt Generator](https://huggingface.co/spaces/merve/ChatGPT-prompt-generator)
 - [ClickPrompt](https://github.com/prompt-engineering/click-prompt)

--- a/pages/tools.it.mdx
+++ b/pages/tools.it.mdx
@@ -6,6 +6,7 @@
 - [Agenta](https://github.com/Agenta-AI/agenta)
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [betterprompt](https://github.com/stjordanis/betterprompt)
+- [ChainForge](https://github.com/ianarawjo/ChainForge)
 - [Chainlit](https://github.com/chainlit/chainlit)
 - [ChatGPT Prompt Generator](https://huggingface.co/spaces/merve/ChatGPT-prompt-generator)
 - [ClickPrompt](https://github.com/prompt-engineering/click-prompt)

--- a/pages/tools.jp.mdx
+++ b/pages/tools.jp.mdx
@@ -6,6 +6,7 @@
 - [Agenta](https://github.com/Agenta-AI/agenta)
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [betterprompt](https://github.com/stjordanis/betterprompt)
+- [ChainForge](https://github.com/ianarawjo/ChainForge)
 - [Chainlit](https://github.com/chainlit/chainlit)
 - [ClickPrompt](https://github.com/prompt-engineering/click-prompt)
 - [DreamStudio](https://beta.dreamstudio.ai)

--- a/pages/tools.kr.mdx
+++ b/pages/tools.kr.mdx
@@ -5,6 +5,7 @@
 - [Agenta](https://github.com/Agenta-AI/agenta)
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [betterprompt](https://github.com/stjordanis/betterprompt)
+- [ChainForge](https://github.com/ianarawjo/ChainForge)
 - [Chainlit](https://github.com/chainlit/chainlit)
 - [ChatGPT Prompt Generator](https://huggingface.co/spaces/merve/ChatGPT-prompt-generator)
 - [ClickPrompt](https://github.com/prompt-engineering/click-prompt)

--- a/pages/tools.pt.mdx
+++ b/pages/tools.pt.mdx
@@ -6,6 +6,7 @@
 - [Agenta](https://github.com/Agenta-AI/agenta)
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [betterprompt](https://github.com/stjordanis/betterprompt)
+- [ChainForge](https://github.com/ianarawjo/ChainForge)
 - [Chainlit](https://github.com/chainlit/chainlit)
 - [ChatGPT Prompt Generator](https://huggingface.co/spaces/merve/ChatGPT-prompt-generator)
 - [ClickPrompt](https://github.com/prompt-engineering/click-prompt)

--- a/pages/tools.ru.mdx
+++ b/pages/tools.ru.mdx
@@ -6,6 +6,7 @@
 - [Agenta](https://github.com/Agenta-AI/agenta)
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [betterprompt](https://github.com/stjordanis/betterprompt)
+- [ChainForge](https://github.com/ianarawjo/ChainForge)
 - [Chainlit](https://github.com/chainlit/chainlit)
 - [ChatGPT Prompt Generator](https://huggingface.co/spaces/merve/ChatGPT-prompt-generator)
 - [ClickPrompt](https://github.com/prompt-engineering/click-prompt)

--- a/pages/tools.tr.mdx
+++ b/pages/tools.tr.mdx
@@ -7,6 +7,7 @@
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [AnySolve](https://www.anysolve.ai)
 - [betterprompt](https://github.com/stjordanis/betterprompt)
+- [ChainForge](https://github.com/ianarawjo/ChainForge)
 - [Chainlit](https://github.com/chainlit/chainlit)
 - [ChatGPT Prompt Generator](https://huggingface.co/spaces/merve/ChatGPT-prompt-generator)
 - [ClickPrompt](https://github.com/prompt-engineering/click-prompt)

--- a/pages/tools.zh.mdx
+++ b/pages/tools.zh.mdx
@@ -6,6 +6,7 @@
 - [Agenta](https://github.com/Agenta-AI/agenta)
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [betterprompt](https://github.com/stjordanis/betterprompt)
+- [ChainForge](https://github.com/ianarawjo/ChainForge)
 - [Chainlit](https://github.com/chainlit/chainlit)
 - [ChatGPT Prompt Generator](https://huggingface.co/spaces/merve/ChatGPT-prompt-generator)
 - [ClickPrompt](https://github.com/prompt-engineering/click-prompt)


### PR DESCRIPTION
Adds ChainForge, an open-source visual toolkit for prompt engineering and LLM auditing. ChainForge is one of the few low/no-code tools that lets you set up complex evaluations and comparisons entirely in a visual front-end UI, and has [several](https://arxiv.org/abs/2409.13588) [published](https://dl.acm.org/doi/abs/10.1145/3654777.3676450) [research papers](https://dl.acm.org/doi/10.1145/3613904.3642016), such as "Who Validates the Validators?" and ChainBuddy.
