### PR TITLE
docs: add BeeAI to the list of agentic frameworks

### DIFF
--- a/ar-pages/research/llm-agents.ar.mdx
+++ b/ar-pages/research/llm-agents.ar.mdx
@@ -133,6 +133,7 @@ Below are notable examples of tools and frameworks that are used to build LLM ag
 - [BMTools](https://github.com/OpenBMB/BMTools): extends language models using tools and serves as a platform for the community to build and share tools.
 - [crewAI](https://www.crewai.io/): AI agent framework reimagined for engineers, offering powerful capabilities with simplicity to build agents and automations.
 - [Phidata](https://github.com/phidatahq/phidata): a toolkit for building AI Assistants using function calling.
+- [BeeAI](https://framework.beeai.dev/): Build production-ready AI agents in both Python and Typescript.
 
 ## LLM Agent Evaluation
 

--- a/pages/research/llm-agents.de.mdx
+++ b/pages/research/llm-agents.de.mdx
@@ -130,6 +130,7 @@ Im Folgenden sind bemerkenswerte Beispiele von Werkzeugen und Frameworks aufgef�
 - [BMTools](https://github.com/OpenBMB/BMTools): erweitert Sprachmodelle mit Werkzeugen und dient als Plattform für die Gemeinschaft zum Erstellen und Teilen von Werkzeugen.
 - [crewAI](https://www.crewai.io/): KI-Agent-Framework neu gedacht für Ingenieure, bietet leistungsstarke Fähigkeiten mit Einfachheit zum Erstellen von Agenten und Automatisierungen.
 - [Phidata](https://github.com/phidatahq/phidata): ein Toolkit zum Erstellen von KI-Assistenten durch Funktionsaufrufe.
+- [BeeAI](https://framework.beeai.dev/): Entwickeln Sie produktionsreife KI-Agenten in Python und TypeScript.
 
 ## LLM Agent Bewertung
 

--- a/pages/research/llm-agents.en.mdx
+++ b/pages/research/llm-agents.en.mdx
@@ -141,6 +141,7 @@ Below are notable examples of tools and frameworks that are used to build LLM ag
 - [BMTools](https://github.com/OpenBMB/BMTools): extends language models using tools and serves as a platform for the community to build and share tools.
 - [crewAI](https://www.crewai.io/): AI agent framework reimagined for engineers, offering powerful capabilities with simplicity to build agents and automations.
 - [Phidata](https://github.com/phidatahq/phidata): a toolkit for building AI Assistants using function calling.
+- [BeeAI](https://framework.beeai.dev/): Build production-ready AI agents in both Python and Typescript.
 
 ## LLM Agent Evaluation
 

--- a/pages/research/llm-agents.kr.mdx
+++ b/pages/research/llm-agents.kr.mdx
@@ -133,6 +133,7 @@ LLM 에이전트를 구축하는 데 사용되는 주요 도구 및 프레임워
 - [BMTools](https://github.com/OpenBMB/BMTools): 언어 모델을 확장하기 위해 도구 사용을 지원하고, 커뮤니티가 도구를 구축하고 공유할 수 있는 플랫폼입니다.
 - [crewAI](https://www.crewai.io/): 엔지니어를 위해 다시 구상된 AI 에이전트 프레임워크로, 강력한 기능을 간단하게 제공합니다.
 - [Phidata](https://github.com/phidatahq/phidata): 함수 호출을 사용해 AI 어시스턴트를 구축하기 위한 툴킷입니다.
+- [BeeAI](https://framework.beeai.dev/): 파이썬과 타입스크립트를 사용하여 프로덕션에 바로 사용할 수 있는 AI 에이전트를 구축합니다.
 
 ## LLM 에이전트 평가
 

--- a/pages/research/llm-agents.zh.mdx
+++ b/pages/research/llm-agents.zh.mdx
@@ -135,6 +135,7 @@ LLM 以多种方式使用这些工具：
 *   [Agents](https://github.com/aiwaves-cn/agents)：一个开源的构建自主语言智能体的库/框架，支持长短期记忆、工具使用、网页导航、多智能体通信等功能，还新增了人机交互和符号控制等新功能，是构建高级智能体的强大工具。
 *   [BMTools](https://github.com/OpenBMB/BMTools)：通过工具扩展语言模型的能力，并为社区提供一个构建和分享这些工具的平台，促进了工具的创新和共享。
 *   [crewAI](https://www.crewai.io/)：为工程师设计的 AI 智能体框架，以简单强大为特点，帮助构建智能体和自动化流程，简化了智能体的开发和部署。
+*   [BeeAI](https://framework.beeai.dev/): 使用 Python 和 Typescript 构建可投入生产的人工智能代理。
 
 ## 大语言模型智能体的评估
 


### PR DESCRIPTION
The BeeAI framework, developed by IBM, offers agentic capabilities, is open-source, has its community, and therefore could be listed in LLM Agents Frameworks.

Repository: https://github.com/i-am-bee/beeai-framework
Docs: https://framework.beeai.dev/