### PR TITLE
Add promptfoo to Tools & Libraries

### DIFF
--- a/pages/tools.en.mdx
+++ b/pages/tools.en.mdx
@@ -57,6 +57,7 @@
 - [Promptmetheus](https://promptmetheus.com)
 - [PromptPerfect](https://promptperfect.jina.ai/)
 - [Promptly](https://trypromptly.com/)
+- [promptfoo](https://github.com/promptfoo/promptfoo) - Test and evaluate LLM applications. Compare prompts, models, and RAG pipelines. Red team with adversarial attacks and integrate into CI/CD.
 - [PromptSource](https://github.com/bigscience-workshop/promptsource)
 - [PromptTools](https://github.com/hegelai/prompttools)
 - [Scale SpellBook](https://scale.com/spellbook)


### PR DESCRIPTION
## Summary

Added [promptfoo](https://github.com/promptfoo/promptfoo) to the Tools & Libraries page.

promptfoo is an open-source tool for testing and evaluating LLM prompts. It helps developers compare model outputs, run regression tests, and detect prompt injection vulnerabilities before shipping to production.

Thanks for maintaining this guide!