### PR TITLE
fix: pin 2 unpinned action(s)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@3ac52d0da9f8ec9ca7b4dc23bb477e36ef9c77a9 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
@@ -51,4 +51,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@3ac52d0da9f8ec9ca7b4dc23bb477e36ef9c77a9 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           
@@ -47,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
           # claude_args: '--model claude-opus-4-1-20250805 --allowed-tools Bash(gh pr:*)'
-


### PR DESCRIPTION
> This is a re-submission of #745, which was closed due to a branch issue on my end. Same fixes, apologies for the noise.

## Security: Harden GitHub Actions workflows

Hey, I found some CI/CD security issues in this repo's GitHub Actions workflows. These are the same vulnerability classes that were exploited in the tj-actions/changed-files supply chain attack. I've been reviewing repos that are affected and submitting fixes where I can.

This PR applies mechanical fixes and flags anything else that needs a manual look. Happy to answer any questions.

### Fixes applied

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/claude-code-review.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/claude.yml` | Pinned 1 third-party action(s) to commit SHA |


### Additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-004 | high | `.github/workflows/claude.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/claude.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-005 | medium | `.github/workflows/claude.yml` | Excessive Permissions on Untrusted Trigger |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks or reference unpinned third-party actions are vulnerable to code injection and supply chain attacks. These are the same vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-attack-and-its-impact) which compromised CI secrets across thousands of repositories.

### How to verify

Review the diff, each change is mechanical and preserves workflow behavior:
- **SHA pinning**: Pins third-party actions to immutable commit SHAs (original version tag preserved as comment)


---

If this PR is not welcome, just close it and I won't send another.