### PR TITLE
feat: add DeepSeek-R1 model page

### DIFF
--- a/pages/models/_meta.en.json
+++ b/pages/models/_meta.en.json
@@ -2,6 +2,7 @@
     "chatgpt": "ChatGPT",
     "claude-3": "Claude 3",
     "code-llama": "Code Llama",
+    "deepseek-r1": "DeepSeek-R1",
     "flan": "Flan",
     "gemini": "Gemini",
     "gemini-advanced": "Gemini Advanced",

--- a/pages/models/deepseek-r1.en.mdx
+++ b/pages/models/deepseek-r1.en.mdx
@@ -1,7 +1,5 @@
 # DeepSeek-R1
 
-import {Screenshot} from 'components/screenshot'
-
 DeepSeek-R1 is an open-source reasoning model developed by DeepSeek AI that achieves performance comparable to OpenAI o1 across math, code, and reasoning tasks. It was released in January 2025 and quickly became one of the most discussed AI models due to its strong benchmark results and open weights.
 
 ## Key Capabilities
@@ -44,10 +42,12 @@ ollama run deepseek-r1:7b
 
 Or via the official API:
 ```python
+import os
 from openai import OpenAI
 
+# Set the DEEPSEEK_API_KEY environment variable with your API key.
 client = OpenAI(
-    api_key="your_api_key",
+    api_key=os.environ.get("DEEPSEEK_API_KEY"),
     base_url="https://api.deepseek.com"
 )
 
@@ -66,7 +66,3 @@ print(response.choices[0].message.content)
 - [DeepSeek-R1 Paper](https://arxiv.org/abs/2501.12948)
 - [DeepSeek GitHub](https://github.com/deepseek-ai/DeepSeek-R1)
 - [DeepSeek API Docs](https://platform.deepseek.com/docs)
-```
-
----
-

--- a/pages/models/deepseek-r1.en.mdx
+++ b/pages/models/deepseek-r1.en.mdx
@@ -1,0 +1,72 @@
+# DeepSeek-R1
+
+import {Screenshot} from 'components/screenshot'
+
+DeepSeek-R1 is an open-source reasoning model developed by DeepSeek AI that achieves performance comparable to OpenAI o1 across math, code, and reasoning tasks. It was released in January 2025 and quickly became one of the most discussed AI models due to its strong benchmark results and open weights.
+
+## Key Capabilities
+
+DeepSeek-R1 uses reinforcement learning (RL) to develop reasoning capabilities, with the model learning to "think" through problems step-by-step before producing a final answer. It supports a context window of 128K tokens and is available in multiple sizes ranging from 1.5B to 671B parameters.
+
+Key features include:
+- Strong performance on math (AIME 2024) and coding benchmarks (Codeforces)
+- Transparent chain-of-thought reasoning visible in outputs
+- Fully open weights under the MIT license
+- Distilled smaller variants (1.5B, 7B, 8B, 14B, 32B, 70B) for local deployment
+
+## Prompting DeepSeek-R1
+
+DeepSeek-R1 responds well to direct, structured prompts. Avoid adding explicit chain-of-thought instructions like "think step by step" — the model generates reasoning traces automatically.
+
+**Basic Prompt:**
+```
+Solve the following: If a train travels 120km in 1.5 hours, what is its average speed?
+```
+
+**Sample Output:**
+```
+Speed = Distance / Time = 120 / 1.5 = 80 km/h
+```
+
+For complex reasoning tasks, simply state the problem clearly:
+```
+Write a Python function that checks whether a number is prime.
+```
+
+DeepSeek-R1 will internally reason through edge cases before producing the final code output.
+
+## Running DeepSeek-R1 Locally
+
+Smaller distilled variants can be run locally via Ollama:
+```bash
+ollama run deepseek-r1:7b
+```
+
+Or via the official API:
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="your_api_key",
+    base_url="https://api.deepseek.com"
+)
+
+response = client.chat.completions.create(
+    model="deepseek-reasoner",
+    messages=[
+        {"role": "user", "content": "Explain the difference between supervised and unsupervised learning."}
+    ]
+)
+
+print(response.choices[0].message.content)
+```
+
+## References
+
+- [DeepSeek-R1 Paper](https://arxiv.org/abs/2501.12948)
+- [DeepSeek GitHub](https://github.com/deepseek-ai/DeepSeek-R1)
+- [DeepSeek API Docs](https://platform.deepseek.com/docs)
+```
+
+---
+


### PR DESCRIPTION
## Description
Adds a new model page for DeepSeek-R1, which is currently missing from the guide despite being one of the most significant AI releases of 2025.

## Changes proposed
- Added `deepseek-r1` entry to `pages/models/_meta.en.json`
- Created `pages/models/deepseek-r1.en.mdx` with full model overview including key capabilities, prompting guide, local deployment instructions, and API usage example

## Why this matters
DeepSeek-R1 achieved performance comparable to OpenAI o1 on reasoning benchmarks and was one of the most discussed open-source AI models of 2025. The guide currently covers GPT-4, Gemini, Claude, Llama but is missing DeepSeek-R1.