### PR TITLE
Fix/dark mode sponsor logo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@svgr/webpack": "^8.1.0",
         "@vercel/analytics": "^0.1.11",
         "clsx": "^2.1.0",
-        "katex": "^0.16.27",
         "next": "^13.5.6",
         "nextra": "^2.13.2",
         "nextra-theme-docs": "^2.13.2",
@@ -25,7 +24,6 @@
       },
       "devDependencies": {
         "@types/node": "18.11.10",
-        "@types/react": "^18.2.0",
         "typescript": "^4.9.5"
       }
     },
@@ -4836,14 +4834,13 @@
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
     },
     "node_modules/katex": {
-      "version": "0.16.47",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
-      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.9.tgz",
+      "integrity": "sha512-fsSYjWS0EEOwvy81j3vRA8TEAhQhKiqO+FQaKWp0m39qwOzHVBgAUBIXWj1pB+O2W3fIpNa6Y9KSKCVbfPhyAQ==",
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
       ],
-      "license": "MIT",
       "dependencies": {
         "commander": "^8.3.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@svgr/webpack": "^8.1.0",
         "@vercel/analytics": "^0.1.11",
         "clsx": "^2.1.0",
+        "katex": "^0.16.27",
         "next": "^13.5.6",
         "nextra": "^2.13.2",
         "nextra-theme-docs": "^2.13.2",
@@ -24,6 +25,7 @@
       },
       "devDependencies": {
         "@types/node": "18.11.10",
+        "@types/react": "^18.2.0",
         "typescript": "^4.9.5"
       }
     },
@@ -4834,13 +4836,14 @@
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
     },
     "node_modules/katex": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.9.tgz",
-      "integrity": "sha512-fsSYjWS0EEOwvy81j3vRA8TEAhQhKiqO+FQaKWp0m39qwOzHVBgAUBIXWj1pB+O2W3fIpNa6Y9KSKCVbfPhyAQ==",
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
       ],
+      "license": "MIT",
       "dependencies": {
         "commander": "^8.3.0"
       },

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -76,12 +76,8 @@ const config: DocsThemeConfig = {
       <div>Last updated on {timestamp.toDateString()}</div>
       <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
         <span>Sponsored by</span>
-        <a href="https://serpapi.com/" target="_blank" rel="noopener noreferrer">
-          <img 
-            src="https://cdn.rawgit.com/standard/standard/master/docs/logos/serpapi.png" 
-            alt="SerpAPI" 
-            style={{ height: '24px', width: 'auto', verticalAlign: 'middle' }}
-          />
+        <a href="https://serpapi.com/" target="_blank" rel="noopener noreferrer" style={{ textDecoration: 'none', fontSize: '1.5rem', fontWeight: '700' }}>
+          SerpAPI
         </a>
       </div>
     </div>


### PR DESCRIPTION
Problem
The "Sponsored by" SerpAPI logo (an image sourced from an external CDN) wasn't visible in dark mode - due to the png image having a transparent/light background that blended into the dark theme, making the sponsor name effectively invisible to dark-mode users.

Fix
Replaced the <img>-based logo with a styled text link instead:

jsx
<a href="https://serpapi.com/" target="_blank" rel="noopener noreferrer" style={{ textDecoration: 'none', fontSize: '1.5rem', fontWeight: '700' }}>
  SerpAPI
</a>

This removes the dependency on the external image asset entirely and uses the theme's existing text color that matches with the brand text format, so it's guaranteed to be visible and legible in both light and dark modes without needing a separate dark-mode-specific asset.

Before / After

Before: logo invisible in dark mode (blends into background) - 

<img width="1622" height="622" alt="image" src="https://github.com/user-attachments/assets/bd8c8d3b-ef36-4703-a91d-67d52872a2b8" />

After: "SerpAPI" renders as bold, clearly visible text in dark mode - 

<img width="1842" height="640" alt="image" src="https://github.com/user-attachments/assets/ddf4c683-cfe9-4490-aec4-17aaaea3c7aa" />

Notes for reviewers

This is a UI/component-level fix (in the site's theme/layout config), not a content change like most PRs in this repo - happy to adjust styling (font size/weight) if you'd prefer something closer to the original branding.
Also tested in light mode to confirm no regression there.